### PR TITLE
cidr to 192.168.56.0/24

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,13 +7,13 @@ Vagrant.configure("2") do |config|
 
     config.vm.define "master" do |master|
         master.vm.box = IMAGE_NAME
-        master.vm.network "private_network", ip:"192.168.50.10"
+        master.vm.network "private_network", ip:"192.168.56.10"
         master.vm.hostname = "master"
         master.vm.provision "ansible_local" do |ansible|
             ansible.compatibility_mode = "2.0"
             ansible.playbook = "kubernetes-setup/master-playbook.yml"
             ansible.extra_vars = {
-                node_ip:"192.168.50.10",
+                node_ip:"192.168.56.10",
             }
         end
         master.vm.provider "virtualbox" do |v|
@@ -25,13 +25,13 @@ Vagrant.configure("2") do |config|
     (1..N).each do |i|
         config.vm.define "node-#{i}" do |node|
             node.vm.box = IMAGE_NAME
-            node.vm.network "private_network", ip:"192.168.50.#{i + 10}"
+            node.vm.network "private_network", ip:"192.168.56.#{i + 10}"
             node.vm.hostname = "node-#{i}"
             node.vm.provision "ansible_local" do |ansible|
                 ansible.compatibility_mode = "2.0"
                 ansible.playbook = "kubernetes-setup/node-playbook.yml"
                 ansible.extra_vars = {
-                    node_ip:"192.168.50.#{i + 10}",
+                    node_ip:"192.168.56.#{i + 10}",
                 }
             end
             node.vm.provider "virtualbox" do |v|

--- a/kubernetes-setup/master-playbook.yml
+++ b/kubernetes-setup/master-playbook.yml
@@ -104,7 +104,7 @@
   - name: Initialize the Kubernetes cluster using kubeadm
     shell:
       cmd: |
-        kubeadm init --apiserver-advertise-address="192.168.50.10" --apiserver-cert-extra-sans="192.168.50.10"  --node-name master --pod-network-cidr=192.168.0.0/16
+        kubeadm init --apiserver-advertise-address="192.168.56.10" --apiserver-cert-extra-sans="192.168.56.10"  --node-name master --pod-network-cidr=192.168.0.0/16
 
   - name: Setup kubeconfig for vagrant user
     command: "{{ item }}"


### PR DESCRIPTION
For some reason, the latest version of VirtualBox (6.1.32) does not take the **192.168.50.0/24** CIDR anymore: 
`Callee RC: E_ACCESSDENIED (0x80070005)`
Instead, the default CIDR now is **192.168.56.0/24**.